### PR TITLE
Add Travis build badge to README page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Technical Documentation
 
+[![Build Status](https://travis-ci.com/alphagov/verify-idp-guidance.svg?branch=master)](https://travis-ci.com/alphagov/verify-idp-guidance)
+
 ## Getting started
 
 To preview or build the website, we need to use the terminal.


### PR DESCRIPTION
The Travis badge looks like this:

![image](https://user-images.githubusercontent.com/17963330/53752393-6581a800-3ea6-11e9-8d7e-50a4b56a14f5.png)

It's a quick indicator if the website is building successfully or not.