### PR TITLE
Merge when published under new domain

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -2,7 +2,7 @@
 host: verify-idp-guidance.cloudapps.digital
 
 # GOV.UK logo set to false until deployed to .service.gov.uk domain
-show_govuk_logo: false
+show_govuk_logo: true
 
 # Header-related options
 service_name: Verify

--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -13,8 +13,8 @@ service_link: https://www.verify.service.gov.uk
 # Links to show on right-hand-side of header
 header_links:
   About: https://www.verify.service.gov.uk
-  Connect: https://www.verify.service.gov.uk/connect
-  Documentation: https://www.docs.verify.service.gov.uk
+# Connect: https://www.verify.service.gov.uk/connect # Does not apply to IDPs
+# Documentation: https://www.docs.verify.service.gov.uk # Does not apply to IDPs
   Support: https://www.verify.service.gov.uk/support
 
 # Enables search functionality. This indexes pages only and is not recommended for single-page sites.

--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -1,5 +1,5 @@
 # Host to use for canonical URL generation (without trailing slash)
-host: verify-idp-guidance.cloudapps.digital
+host: www.identity-providers.verify.service.gov.uk
 
 # GOV.UK logo set to false until deployed to .service.gov.uk domain
 show_govuk_logo: true

--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -35,7 +35,7 @@ collapsible_nav: true
 max_toc_heading_level: 3
 
 # Prevent robots from indexing (e.g. whilst in development)
-prevent_indexing: true
+prevent_indexing: false
 
 show_contribution_banner: true
 github_repo: alphagov/verify-idp-guidance

--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -5,7 +5,7 @@ host: verify-idp-guidance.cloudapps.digital
 show_govuk_logo: false
 
 # Header-related options
-service_name: Guidance for identity providers
+service_name: Verify
 service_link: verify-idp-guidance.cloudapps.digital
 ## phase of your project, for example ALPHA, BETA
 # phase: TESTING PHASE

--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -6,7 +6,7 @@ show_govuk_logo: false
 
 # Header-related options
 service_name: Verify
-service_link: verify-idp-guidance.cloudapps.digital
+service_link: www.verify.service.gov.uk
 ## phase of your project, for example ALPHA, BETA
 # phase: TESTING PHASE
 

--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -7,7 +7,8 @@ show_govuk_logo: false
 # Header-related options
 service_name: Guidance for identity providers
 service_link: verify-idp-guidance.cloudapps.digital
-phase: TESTING PHASE
+## phase of your project, for example ALPHA, BETA
+# phase: TESTING PHASE
 
 # Links to show on right-hand-side of header
 header_links:

--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -1,12 +1,12 @@
 # Host to use for canonical URL generation (without trailing slash)
-host: www.identity-providers.verify.service.gov.uk
+host: https://www.identity-providers.verify.service.gov.uk
 
 # GOV.UK logo set to false until deployed to .service.gov.uk domain
 show_govuk_logo: true
 
 # Header-related options
 service_name: Verify
-service_link: www.verify.service.gov.uk
+service_link: https://www.verify.service.gov.uk
 ## phase of your project, for example ALPHA, BETA
 # phase: TESTING PHASE
 


### PR DESCRIPTION
There are some changes that should happen in the appearance of the IDP guidance header when published on the new domain. It should look like this:

![image](https://user-images.githubusercontent.com/17963330/56364984-c57aa680-61e7-11e9-9860-b6ab7caae55c.png)

This PR contains all the necessary frontend and backend changes - there is one commit for every change.

Merge this PR once the guidance has been published on the new domain.
