### PR TITLE
Minor copy amends

### DIFF
--- a/source/3-monthly-report/index.html.md.erb
+++ b/source/3-monthly-report/index.html.md.erb
@@ -23,7 +23,7 @@ And for the next 3 months:
 * any planned changes to the user interface
 * any planned user research
 
-The Verify team uses the information provided to decide whether changes are justified, and whether they meet Verify’s rules and guidance.
+The Verify team uses the information provided to decide whether changes meet Verify’s rules and guidance.
 
 ## Report template 
 
@@ -55,7 +55,7 @@ If the Verify team notice what appears to be a drop in performance, they will:
 The Verify team will consider factors beyond the identity provider’s control, or which don’t relate to the user journey. These factors might include:
 
 * large volumes of traffic from a service which performs poorly
-major hub outages 
+* major hub outages 
 * seasonal fluctuations 
 * an A/B test or other Verify initiative
 


### PR DESCRIPTION
- Removed word "justified" due to strong implications
- Replaced missing bullet point