### PR TITLE
Hub-728: redirect on idp site

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM ruby:2.6.5-buster
+
+EXPOSE 4567:4567
+EXPOSE 35729:35729
+
+WORKDIR /usr/src/gems
+
+COPY ./Gemfile /usr/src/gems
+
+RUN apt-get update && apt-get install -y nodejs
+
+RUN bundle install
+
+WORKDIR /usr/src/docs
+
+CMD [ "bundle", "exec", "--gemfile=/usr/src/gems/Gemfile", "middleman", "server" ]

--- a/config.rb
+++ b/config.rb
@@ -6,4 +6,11 @@ GovukTechDocs::SourceUrls.class_eval do
   end
 end
 
+ready do
+  sitemap.resources
+         .map(&:path)
+         .select { |path| path.end_with?('.html') }
+         .each { |page| redirect page, to: config[:tech_docs][:service_link] }
+end
+
 GovukTechDocs.configure(self)

--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -46,3 +46,19 @@ prevent_indexing: false
 
 show_contribution_banner: true
 github_repo: alphagov/verify-idp-guidance
+
+redirects:
+  /index.html: https://www.verify.service.gov.uk/
+  /user-research/index.html: https://www.verify.service.gov.uk/
+  /design-and-content/index.html: https://www.verify.service.gov.uk/
+  /accessibility/index.html: https://www.verify.service.gov.uk/
+  /accessibility-statement/index.html: https://www.verify.service.gov.uk/
+  /design-patterns/index.html: https://www.verify.service.gov.uk/
+  /branding/index.html: https://www.verify.service.gov.uk/
+  /3-monthly-report/index.html: https://www.verify.service.gov.uk/
+
+
+
+
+
+

--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -47,16 +47,6 @@ prevent_indexing: false
 show_contribution_banner: true
 github_repo: alphagov/verify-idp-guidance
 
-redirects:
-  /index.html: https://www.verify.service.gov.uk/
-  /user-research/index.html: https://www.verify.service.gov.uk/
-  /design-and-content/index.html: https://www.verify.service.gov.uk/
-  /accessibility/index.html: https://www.verify.service.gov.uk/
-  /accessibility-statement/index.html: https://www.verify.service.gov.uk/
-  /design-patterns/index.html: https://www.verify.service.gov.uk/
-  /branding/index.html: https://www.verify.service.gov.uk/
-  /3-monthly-report/index.html: https://www.verify.service.gov.uk/
-
 
 
 

--- a/preview-with-docker.sh
+++ b/preview-with-docker.sh
@@ -1,0 +1,6 @@
+#! /bin/bash
+set -e
+
+docker build . --tag verify-idp-guidance
+
+docker run --rm -p 4567:4567 -p 35729:35729 -v $(pwd):/usr/src/docs -it verify-idp-guidance


### PR DESCRIPTION
This is related to https://govukverify.atlassian.net/browse/HUB-728

This PR ensures visits to [IDP Guidance](https://identity-providers.verify.service.gov.uk/) are redirected to [Verify Service link](https://www.verify.service.gov.uk/) 